### PR TITLE
Improve dialog windows behavior

### DIFF
--- a/io.go
+++ b/io.go
@@ -32,7 +32,7 @@ func setupDirs() {
 	createDir(cDir)
 	// copy files if not found
 	copyFile("/usr/share/nwgocc/cli_commands", fmt.Sprintf("%s/cli_commands", cDir))
-	copyFile("/usr/share/nwgocc/%s", fmt.Sprintf("%s/%s", cDir, *configFile))
+	copyFile("/usr/share/nwgocc/config.json", fmt.Sprintf("%s/%s", cDir, *configFile))
 	copyFile("/usr/share/nwgocc/style.css", fmt.Sprintf("%s/style.css", cDir))
 
 	// Create data dir if not found (contains icons_light/, icons_dark/, preferences.json)

--- a/nwgocc.go
+++ b/nwgocc.go
@@ -23,6 +23,7 @@ var (
 	iconsDir    string
 	settings    Settings
 	config      Configuration
+	win         *gtk.Window
 )
 
 var configFile = flag.String("c", "config.json", "user's templates: Config file name")

--- a/preferences.go
+++ b/preferences.go
@@ -195,6 +195,8 @@ func setupPreferencesWindow() {
 		gtk.MainQuit()
 	})
 
+	prefWindow.SetTransientFor(win)
+	prefWindow.SetModal(true)
 	prefWindow.Show()
 	prefWindow.Connect("key-release-event", handleEscape)
 }

--- a/preferences.go
+++ b/preferences.go
@@ -313,6 +313,8 @@ func setupCmdDialog(command *string) {
 
 	win.SetTransientFor(prefWindow)
 	win.SetModal(true)
+	win.SetKeepAbove(true)
+	win.SetDecorated(false)
 	win.SetTypeHint(gdk.WINDOW_TYPE_HINT_DIALOG)
 	win.SetTitle("nwgocc: Edit command")
 	win.SetProperty("name", "preferences")


### PR DESCRIPTION
- Preferences set transient for main window, modal
- command edition window w/o decorations
- first run / restore defaults: fixed erroneous source file path for `config.json`